### PR TITLE
Improve streaming parsers

### DIFF
--- a/META
+++ b/META
@@ -7,7 +7,7 @@ ppx = "./ppx_sedlex"
 package "ppx" (
   version = "1.99.2"
   description = "ppx implementation of sedlex"
-  requires = "ppx_tools"
+  requires = "ppx_tools gen"
   archive(byte) = "sedlex.cma"
   archive(native) = "sedlex.cmxa"
 )

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -10,19 +10,19 @@ test: tokenizer$(EXE) complement$(EXE)
 	./complement$(EXE)
 
 tokenizer$(EXE): tokenizer.ml
-	ocamlc -ppx "../src/syntax/ppx_sedlex$(EXE)" -I ../src/lib -o tokenizer$(EXE) sedlexing.cma tokenizer.ml
+	ocamlfind ocamlc -package gen -ppx "../src/syntax/ppx_sedlex$(EXE)" -I ../src/lib -o tokenizer$(EXE) -linkpkg sedlexing.cma tokenizer.ml
 
 complement$(EXE): complement.ml
-	ocamlc -ppx "../src/syntax/ppx_sedlex$(EXE)" -I ../src/lib -o complement$(EXE) sedlexing.cma complement.ml
+	ocamlfind ocamlc -package gen -ppx "../src/syntax/ppx_sedlex$(EXE)" -I ../src/lib -o complement$(EXE) -linkpkg sedlexing.cma complement.ml
 
 .PHONY: with_driver
 with_driver: tokenizer.ml
-	ocamlc -ppx "ppx_driver ../src/syntax/sedlex.cma" -I ../src/lib -o tokenizer$(EXE) sedlexing.cma tokenizer.ml
+	ocamlfind ocamlc -package gen -ppx "ppx_driver ../src/syntax/sedlex.cma" -I ../src/lib -o tokenizer$(EXE) sedlexing.cma tokenizer.ml
 
 .PHONY: with_findlib
 with_findlib: tokenizer.ml
-	ocamlfind ocamlc -c -package sedlex tokenizer.ml
-	ocamlfind ocamlc -o tokenizer$(EXE) -linkpkg -package sedlex tokenizer.cmo
+	ocamlfind ocamlc -c -package sedlex -package gen tokenizer.ml
+	ocamlfind ocamlc -o tokenizer$(EXE) -linkpkg -package sedlex -package gen tokenizer.cmo
 
 clean:
 	rm -f *~ *.cm* *.a *.lib *.o *.obj tokenizer$(EXE) complement$(EXE)

--- a/src/lib/Makefile
+++ b/src/lib/Makefile
@@ -8,17 +8,17 @@ all: sedlexing.cma
 opt: sedlexing.cmxa
 
 sedlexing.cma: $(MODS:.cmo=.mli) $(MODS:.cmo=.ml)
-	ocamlc -w +A-4-9 -safe-string -c $(MODS:.cmo=.mli) $(MODS:.cmo=.ml)
-	ocamlc -a -o sedlexing.cma $(MODS)
+	ocamlfind ocamlc -package gen -w +A-4-9 -safe-string -c $(MODS:.cmo=.mli) $(MODS:.cmo=.ml)
+	ocamlfind ocamlc -package gen -a -o sedlexing.cma $(MODS)
 
 sedlexing.cmxa: $(MODS:.cmo=.mli) $(MODS:.cmo=.ml)
-	ocamlopt -safe-string -c $(MODS:.cmo=.mli) $(MODS:.cmo=.ml)
-	ocamlopt -a -o sedlexing.cmxa $(MODS:.cmo=.cmx)
+	ocamlfind ocamlopt -package gen -safe-string -c $(MODS:.cmo=.mli) $(MODS:.cmo=.ml)
+	ocamlfind ocamlopt -package gen -a -o sedlexing.cmxa $(MODS:.cmo=.cmx)
 
 doc:
 	rm -rf ../../libdoc
 	mkdir ../../libdoc
-	ocamldoc -html sedlexing.mli -d ../../libdoc
+	ocamlfind ocamldoc -package gen -html sedlexing.mli -d ../../libdoc
 
 
 

--- a/src/lib/sedlexing.mli
+++ b/src/lib/sedlexing.mli
@@ -48,8 +48,12 @@ val create: (int array -> int -> int -> int) -> lexbuf
         position [pos], and return the number of characters provided. A
         return value of 0 means end of input. *)
 
-val from_stream: int Gen.t -> lexbuf
+val from_gen: int Gen.t -> lexbuf
     (** Create a lexbuf from a stream of Unicode code points. *)
+
+val from_stream: int Stream.t -> lexbuf
+    (** Create a lexbuf from a stream of Unicode code points. *)
+    [@@ocaml.deprecated "Use [Sedlexing.from_gen] instead."]
 
 val from_int_array: int array -> lexbuf
     (** Create a lexbuf from an array of Unicode code points. *)
@@ -136,9 +140,14 @@ val backtrack: lexbuf -> int
 (** {6 Support for common encodings} *)
 
 module Latin1: sig
-  val from_stream: char Gen.t -> lexbuf
+  val from_gen: char Gen.t -> lexbuf
       (** Create a lexbuf from a Latin1 encoded stream (ie a stream
           of Unicode code points in the range [0..255]) *)
+
+  val from_stream: char Stream.t -> lexbuf
+      (** Create a lexbuf from a Latin1 encoded stream (ie a stream
+          of Unicode code points in the range [0..255]) *)
+      [@@ocaml.deprecated "Use [Sedlexing.Latin1.from_gen] instead."]
 
   val from_channel: in_channel -> lexbuf
       (** Create a lexbuf from a Latin1 encoded input channel.
@@ -166,8 +175,12 @@ end
 
 
 module Utf8: sig
-  val from_stream: char Gen.t -> lexbuf
+  val from_gen: char Gen.t -> lexbuf
       (** Create a lexbuf from a UTF-8 encoded stream. *)
+
+  val from_stream: char Stream.t -> lexbuf
+      (** Create a lexbuf from a UTF-8 encoded stream. *)
+      [@@ocaml.deprecated "Use [Sedlexing.Utf8.from_gen] instead."]
 
   val from_channel: in_channel -> lexbuf
       (** Create a lexbuf from a UTF-8 encoded input channel. *)
@@ -186,8 +199,8 @@ end
 module Utf16: sig
   type byte_order = Little_endian | Big_endian
 
-  val from_stream: char Gen.t -> byte_order option -> lexbuf
-      (** [from_utf16_stream s opt_bo] creates a lexbuf from an UTF-16
+  val from_gen: char Gen.t -> byte_order option -> lexbuf
+      (** [Utf16.from_gen s opt_bo] creates a lexbuf from an UTF-16
           encoded stream. If [opt_bo] matches with [None] the function
           expects a BOM (Byte Order Mark), and takes the byte order as
           [Utf16.Big_endian] if it cannot find one. When [opt_bo]
@@ -196,11 +209,15 @@ module Utf16: sig
           ignore it and a `wrong' BOM ([0xfffe]) will raise
           Utf16.InvalidCodepoint.  *)
 
+  val from_stream: char Stream.t -> byte_order option -> lexbuf
+      (** Works as [Utf16.from_gen] with a [stream]. *)
+      [@@ocaml.deprecated "Use [Sedlexing.Utf16.from_gen] instead."]
+
   val from_channel: in_channel -> byte_order option-> lexbuf
-      (** Works as [from_utf16_stream] with an [in_channel]. *)
+      (** Works as [Utf16.from_gen] with an [in_channel]. *)
 
   val from_string: string -> byte_order option -> lexbuf
-      (** Works as [from_utf16_stream] with a [string]. *)
+      (** Works as [Utf16.from_gen] with a [string]. *)
 
   val lexeme: lexbuf -> byte_order -> bool -> string
       (** [utf16_lexeme lb bo bom] as [Sedlexing.lexeme] with a result

--- a/src/lib/sedlexing.mli
+++ b/src/lib/sedlexing.mli
@@ -48,7 +48,7 @@ val create: (int array -> int -> int -> int) -> lexbuf
         position [pos], and return the number of characters provided. A
         return value of 0 means end of input. *)
 
-val from_stream: int Stream.t -> lexbuf
+val from_stream: int Gen.t -> lexbuf
     (** Create a lexbuf from a stream of Unicode code points. *)
 
 val from_int_array: int array -> lexbuf
@@ -136,7 +136,7 @@ val backtrack: lexbuf -> int
 (** {6 Support for common encodings} *)
 
 module Latin1: sig
-  val from_stream: char Stream.t -> lexbuf
+  val from_stream: char Gen.t -> lexbuf
       (** Create a lexbuf from a Latin1 encoded stream (ie a stream
           of Unicode code points in the range [0..255]) *)
 
@@ -166,7 +166,7 @@ end
 
 
 module Utf8: sig
-  val from_stream: char Stream.t -> lexbuf
+  val from_stream: char Gen.t -> lexbuf
       (** Create a lexbuf from a UTF-8 encoded stream. *)
 
   val from_channel: in_channel -> lexbuf
@@ -186,7 +186,7 @@ end
 module Utf16: sig
   type byte_order = Little_endian | Big_endian
 
-  val from_stream: char Stream.t -> byte_order option -> lexbuf
+  val from_stream: char Gen.t -> byte_order option -> lexbuf
       (** [from_utf16_stream s opt_bo] creates a lexbuf from an UTF-16
           encoded stream. If [opt_bo] matches with [None] the function
           expects a BOM (Byte Order Mark), and takes the byte order as


### PR DESCRIPTION
On my (arguably quite small) examples, these two patches improve performances by around 30% to 50%.

Also, Gen is much nicer to use than Stream and some part of the code could be improved using standard function, if you choose to accept this patch.

I don't have pretty numbers, because

  1) I don't have big enough datasets.
  2) Benchmarking process where IO plays a big role is messy.