### PR TITLE
Add Sub(a,b) [subtract] and Intersect(a,b) operators to sedlex%matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,17 @@ Regular expressions are syntactically OCaml patterns:
 - Plus R : equivalent to R, R*
 - Opt R : equivalent to ("" | R)
 - Chars "..." : recognize any character in the string
-- Compl R : assume that R is a single-character regexp (see below)
+- Compl R : assume that R is a single-character length regexp (see below)
   and recognize the complement set
+- Sub (R1,R2) : assume that R is a single-character length regexp (see below)
+  and recognize the set of items in R1 but not in R2 ("subtract")
+- Intersect (R1,R2) : assume that R is a single-character length regexp (see
+  below) and recognize the set of items which are in both R1 and R2
 - lid (lowercase identifier) : reference a named regexp (see below)
 
-A single-character regexp is a regexp which does not contain (after expansion
-of references) concatenation, Star, Plus, Opt or string constants with a
-length different from one.
+A single-character length regexp is a regexp which does not contain (after
+expansion of references) concatenation, Star, Plus, Opt or string constants
+with a length different from one.
 
 
 

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -264,13 +264,16 @@ let err loc s =
   raise (Location.Error (Location.error ~loc ("Sedlex: " ^ s)))
 
 let regexp_of_pattern env =
-  let rec char_pair_op func name p p0 p1 = (* Construct something like Sub(a,b) *)
-    begin match func (aux p0) (aux p1) with
-      | Some r -> r
-      | None ->
-        err p.ppat_loc @@
-          "the "^name^" operator can only applied to single-character length regexps"
-    end
+  let rec char_pair_op func name p tuple = (* Construct something like Sub(a,b) *)
+    match tuple with
+      | Some {ppat_desc=Ppat_tuple (p0 :: p1 :: [])} ->
+        begin match func (aux p0) (aux p1) with
+        | Some r -> r
+        | None ->
+          err p.ppat_loc @@
+            "the "^name^" operator can only applied to single-character length regexps"
+        end
+      | _ -> err p.ppat_loc @@ "the "^name^" operator requires two arguments, like "^name^"(a,b)"
   and aux p = (* interpret one pattern node *)
     match p.ppat_desc with
     | Ppat_or (p1, p2) -> Sedlex.alt (aux p1) (aux p2)
@@ -284,23 +287,31 @@ let regexp_of_pattern env =
         Sedlex.plus (aux p)
     | Ppat_construct ({txt = Lident "Opt"}, Some p) ->
         Sedlex.alt Sedlex.eps (aux p)
-    | Ppat_construct ({txt = Lident "Compl"}, Some p0) ->
-        begin match Sedlex.compl (aux p0) with
-        | Some r -> r
-        | None ->
-          err p.ppat_loc
-            "the Compl operator can only applied to a single-character length regexp"
+    | Ppat_construct ({txt = Lident "Compl"}, arg) ->
+        begin match arg with
+        | Some p0 ->
+            begin match Sedlex.compl (aux p0) with
+            | Some r -> r
+            | None ->
+              err p.ppat_loc
+                "the Compl operator can only applied to a single-character length regexp"
+            end
+        | _ -> err p.ppat_loc "the Compl operator requires an argument"
         end
-    | Ppat_construct ({ txt = Lident "Sub" }, Some {ppat_desc=Ppat_tuple (p0 :: p1 :: [])}) ->
-        char_pair_op Sedlex.subtract "Sub" p p0 p1
-    | Ppat_construct ({ txt = Lident "Intersect" }, Some {ppat_desc=Ppat_tuple (p0 :: p1 :: [])}) ->
-        char_pair_op Sedlex.intersection "Intersect" p p0 p1
-    | Ppat_construct ({txt = Lident "Chars"}, Some {ppat_desc=Ppat_constant (Const_string (s, _))}) ->
-        let c = ref Cset.empty in
-        for i = 0 to String.length s - 1 do
-          c := Cset.union !c (Cset.singleton (Char.code s.[i]))
-        done;
-        Sedlex.chars !c
+    | Ppat_construct ({ txt = Lident "Sub" }, arg) ->
+        char_pair_op Sedlex.subtract "Sub" p arg
+    | Ppat_construct ({ txt = Lident "Intersect" }, arg) ->
+        char_pair_op Sedlex.intersection "Intersect" p arg
+    | Ppat_construct ({txt = Lident "Chars"}, arg) ->
+        begin match arg with
+        | Some {ppat_desc=Ppat_constant (Const_string (s, _))} ->
+            let c = ref Cset.empty in
+            for i = 0 to String.length s - 1 do
+              c := Cset.union !c (Cset.singleton (Char.code s.[i]))
+            done;
+            Sedlex.chars !c
+        | _ -> err p.ppat_loc "the Chars operator requires a string argument"
+        end
     | Ppat_interval (Const_char c1, Const_char c2) ->
         Sedlex.chars (Cset.interval (Char.code c1) (Char.code c2))
     | Ppat_interval (Const_int i1, Const_int i2) ->

--- a/src/syntax/sedlex.ml
+++ b/src/syntax/sedlex.ml
@@ -50,7 +50,7 @@ let plus r succ =
   n.eps <- [nr; succ];
   nr
 
-let eps succ = succ
+let eps succ = succ (* eps for epsilon *)
 
 let compl r =
   let n = new_node () in
@@ -59,6 +59,19 @@ let compl r =
     Some (chars (Cset.difference Cset.any c))
   | _ ->
     None
+
+let pair_op f r0 r1 = (* Construct subtract or intersection *)
+  let n = new_node () in
+  let to_chars r = is_chars n (r n) in
+  match to_chars r0, to_chars r1 with
+  | Some c0, Some c1 ->
+    Some (chars (f c0 c1))
+  | _ ->
+    None
+
+let subtract = pair_op Cset.difference
+
+let intersection = pair_op Cset.intersection
 
 let compile_re re =
   let final = new_node () in

--- a/src/syntax/sedlex.mli
+++ b/src/syntax/sedlex.mli
@@ -12,10 +12,13 @@ val plus: regexp -> regexp
 val eps: regexp
 
 val compl: regexp -> regexp option
-val subtract: regexp -> regexp -> regexp option
-val intersection: regexp -> regexp -> regexp option
    (* If the argument is a single [chars] regexp, returns a regexp
       which matches the complement set.  Otherwise returns [None]. *)
-
+val subtract: regexp -> regexp -> regexp option
+   (* If each argument is a single [chars] regexp, returns a regexp
+      which matches the set (arg1 - arg2).  Otherwise returns [None]. *)
+val intersection: regexp -> regexp -> regexp option
+   (* If each argument is a single [chars] regexp, returns a regexp
+      which matches the intersection set.  Otherwise returns [None]. *)
 
 val compile: regexp array -> ((Cset.t * int) array * bool array) array

--- a/src/syntax/sedlex.mli
+++ b/src/syntax/sedlex.mli
@@ -12,6 +12,8 @@ val plus: regexp -> regexp
 val eps: regexp
 
 val compl: regexp -> regexp option
+val subtract: regexp -> regexp -> regexp option
+val intersection: regexp -> regexp -> regexp option
    (* If the argument is a single [chars] regexp, returns a regexp
       which matches the complement set.  Otherwise returns [None]. *)
 


### PR DESCRIPTION
...Both ops work only on character sets. Also fix up a couple comments and confusing error language on Compl.

My use case is something like Sub(white_space, "\n"). I am not sure why anyone would want Intersect. It seems like it could be useful very occasionally.

Here's my test program for the additions:

(* Simple sedlex sample *)

      let () = 
            let rec lex buf = 
                  match%sedlex buf with
                        | white_space -> print_endline "\tWhitespace"; lex buf
                        | Sub (Chars "ab","b") -> print_endline "a"; lex buf
                        | (Chars "ab"|"c") -> print_endline "abc"; lex buf
                        | Intersect ("d", Chars "abd") -> print_endline "d"; lex buf
                        | eof -> print_endline "\tEnd"
                        | any -> print_endline "Other"; lex buf
                        | _ -> failwith "Internal failure: Reached impossible place"
            in lex @@ Sedlexing.Utf8.from_string "a b c d e"

First time doing something like this in the ocaml community, let me know if I did anything suboptimal :O