### PR TITLE
Track line and position-within-line numbers

### DIFF
--- a/src/lib/sedlexing.mli
+++ b/src/lib/sedlexing.mli
@@ -22,6 +22,17 @@
     Of course, you'll probably want to define functions like [lexeme] to
     be used in the lexers semantic actions.  *)
 
+type position_info = {
+  position : int;
+  line : int;
+  line_position : int;
+}
+      (** Lexer position info structure. Fields:
+          * position: offset in stream
+          * line: number of newlines preceding offset
+          * line_position: offset since beginning of line
+          position, line, and line_position all start at 0 *)
+
 type lexbuf
       (** The type of lexer buffers. A lexer buffer is the argument passed
           to the scanning functions defined by the generated lexers.
@@ -75,6 +86,19 @@ val loc: lexbuf -> int * int
     (** [Sedlexing.loc lexbuf] returns the pair
         [(Sedlexing.lexeme_start lexbuf,Sedlexing.lexeme_end
         lexbuf)]. *)
+
+val lexeme_start_extended: lexbuf -> position_info
+    (** [Sedlexing.lexeme_start_extended lexbuf] returns a position info
+        structure for the first code point of the matched string. *)
+
+val lexeme_end_extended: lexbuf -> position_info
+    (** [Sedlexing.lexeme_end_extended lexbuf] returns a position info
+        structure for the last code point of the matched string. *)
+
+val loc_extended: lexbuf -> position_info * position_info
+    (** [Sedlexing.loc_extended lexbuf] returns the pair
+        [(Sedlexing.lexeme_start_extended lexbuf,
+        Sedlexing.lexeme_end_extended lexbuf)]. *)
 
 val lexeme_length: lexbuf -> int
     (** [Sedlexing.loc lexbuf] returns the difference

--- a/src/lib/sedlexing.mli
+++ b/src/lib/sedlexing.mli
@@ -22,17 +22,6 @@
     Of course, you'll probably want to define functions like [lexeme] to
     be used in the lexers semantic actions.  *)
 
-type position_info = {
-  position : int;
-  line : int;
-  line_position : int;
-}
-      (** Lexer position info structure. Fields:
-          * position: offset in stream
-          * line: number of newlines preceding offset
-          * line_position: offset since beginning of line
-          position, line, and line_position all start at 0 *)
-
 type lexbuf
       (** The type of lexer buffers. A lexer buffer is the argument passed
           to the scanning functions defined by the generated lexers.
@@ -87,18 +76,21 @@ val loc: lexbuf -> int * int
         [(Sedlexing.lexeme_start lexbuf,Sedlexing.lexeme_end
         lexbuf)]. *)
 
-val lexeme_start_extended: lexbuf -> position_info
-    (** [Sedlexing.lexeme_start_extended lexbuf] returns a position info
-        structure for the first code point of the matched string. *)
+val lexeme_start_position: lexbuf -> Lexing.position
+    (** [Sedlexing.lexeme_start_position lexbuf] returns a Lexing.position
+        structure for the first code point of the matched string.
+        pos_fname is always set to 0. *)
 
-val lexeme_end_extended: lexbuf -> position_info
-    (** [Sedlexing.lexeme_end_extended lexbuf] returns a position info
-        structure for the last code point of the matched string. *)
+val lexeme_end_position: lexbuf -> Lexing.position
+    (** [Sedlexing.lexeme_end_position lexbuf] returns a Lexing.position
+        structure for the last code point of the matched string.
+        pos_fname is always set to 0. *)
 
-val loc_extended: lexbuf -> position_info * position_info
+val loc_position: lexbuf -> Lexing.position * Lexing.position
     (** [Sedlexing.loc_extended lexbuf] returns the pair
-        [(Sedlexing.lexeme_start_extended lexbuf,
-        Sedlexing.lexeme_end_extended lexbuf)]. *)
+        [(Sedlexing.lexeme_start_position lexbuf,
+        Sedlexing.lexeme_end_position lexbuf)].
+        pos_fname is always set to 0. *)
 
 val lexeme_length: lexbuf -> int
     (** [Sedlexing.loc lexbuf] returns the difference


### PR DESCRIPTION
"Sedlexing now tracks position by a position_info structure instead of int. In addition to array position, position_info tracks line and position in line of each point in the buffer (where "line" is demarcated by `\n`)"

Things I am uncertain about here:
- I added two "FIXME: Requesting comment"s in sedlexing.ml for lines that I didn't understand.
- Is it sufficient to use `\n` as the sole determinor of line/linepos? (You won't work right on Mac OS 9 systems!)
- Should any other position information (such as byte offset) be tracked?
- Should there be any way to customize the kind of position information tracked?
- In order to keep the old API stable, I added the accessors in sedlexing.mli at "lexeme_start_extended", "lexeme_end_extended". Are these good names?

Here's my test code for this change:

```
  (* Simple sedlex sample *)
  let () = 
        let position_info i = "[pos:"^(string_of_int i.Sedlexing.position)^
              " line:"^(string_of_int i.Sedlexing.line)^
              " inline:"^(string_of_int i.Sedlexing.line_position)^"]" in
        let rec lex buf = 
              match%sedlex buf with
                    | eof -> print_endline "\tEnd"
                    | any ->
                          print_endline @@ "("^(Sedlexing.Utf8.lexeme buf)^")"^
                                " start " ^(position_info @@ Sedlexing.lexeme_start_extended buf)^
                                " end "   ^(position_info @@ Sedlexing.lexeme_end_extended   buf);
                          lex buf
                    | _ -> failwith "Internal failure: Reached impossible place"
        in lex @@ Sedlexing.Utf8.from_string "a   \nbc\n\n    \n"
```
