### PR TITLE
Fix for Sedlex failing to build on 4.03.

### DIFF
--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -306,7 +306,7 @@ let regexp_of_pattern env =
         char_pair_op Sedlex.intersection "Intersect" p arg
     | Ppat_construct ({txt = Lident "Chars"}, arg) ->
         let const = (function 
-          | Some {ppat_desc=Ppat_constant (const)} -> Some (constant_type const)
+          | Some {ppat_desc=Ppat_constant (const)} -> Some (of_constant const)
           | _ -> None) arg 
         in 
         begin match const with
@@ -319,14 +319,14 @@ let regexp_of_pattern env =
         | _ -> err p.ppat_loc "the Chars operator requires a string argument"
         end
     | Ppat_interval (i_start, i_end) -> 
-        begin match constant_type i_start, constant_type i_end with
+        begin match of_constant i_start, of_constant i_end with
           | Pconst_char c1, Pconst_char c2 -> Sedlex.chars (Cset.interval (Char.code c1) (Char.code c2))
           | Pconst_integer(i1,_), Pconst_integer(i2,_) -> 
               Sedlex.chars (Cset.interval (codepoint (int_of_string i1)) (codepoint (int_of_string i2)))
           | _ -> err p.ppat_loc "this pattern is not a valid interval regexp"
         end 
     | Ppat_constant (const) -> 
-        begin match constant_type const with 
+        begin match of_constant const with 
           | Pconst_string (s, _) -> regexp_for_string s
           | Pconst_char c -> regexp_for_char c
           | Pconst_integer(i,_) -> Sedlex.chars (Cset.singleton (codepoint (int_of_string i)))

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -76,7 +76,6 @@ let decision_table p =
 
 
 let appfun s l = app (evar s) l
-(* let pint i = Pat.constant (Const_int i) *)
 let glb_value name def = Str.value Nonrecursive [Vb.mk (pvar name) def]
 
 (* Named regexps *)

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -7,7 +7,6 @@ open Parsetree
 open Asttypes
 open Ast_helper
 open Ast_convenience
-open Ast_convenience.Constant
 
 module Cset = Sedlex_cset
 
@@ -306,7 +305,7 @@ let regexp_of_pattern env =
         char_pair_op Sedlex.intersection "Intersect" p arg
     | Ppat_construct ({txt = Lident "Chars"}, arg) ->
         let const = (function 
-          | Some {ppat_desc=Ppat_constant (const)} -> Some (of_constant const)
+          | Some {ppat_desc=Ppat_constant (const)} -> Some (Constant.of_constant const)
           | _ -> None) arg 
         in 
         begin match const with
@@ -319,14 +318,14 @@ let regexp_of_pattern env =
         | _ -> err p.ppat_loc "the Chars operator requires a string argument"
         end
     | Ppat_interval (i_start, i_end) -> 
-        begin match of_constant i_start, of_constant i_end with
+        begin match Constant.of_constant i_start, Constant.of_constant i_end with
           | Pconst_char c1, Pconst_char c2 -> Sedlex.chars (Cset.interval (Char.code c1) (Char.code c2))
           | Pconst_integer(i1,_), Pconst_integer(i2,_) -> 
               Sedlex.chars (Cset.interval (codepoint (int_of_string i1)) (codepoint (int_of_string i2)))
           | _ -> err p.ppat_loc "this pattern is not a valid interval regexp"
         end 
     | Ppat_constant (const) -> 
-        begin match of_constant const with 
+        begin match Constant.of_constant const with 
           | Pconst_string (s, _) -> regexp_for_string s
           | Pconst_char c -> regexp_for_char c
           | Pconst_integer(i,_) -> Sedlex.chars (Cset.singleton (codepoint (int_of_string i)))

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -76,7 +76,7 @@ let decision_table p =
 
 
 let appfun s l = app (evar s) l
-let pint i = Pat.constant (Const_int i)
+let pint i = Pat.constant (Pconst_integer(string_of_int i, None))
 let glb_value name def = Str.value Nonrecursive [Vb.mk (pvar name) def]
 
 (* Named regexps *)
@@ -306,7 +306,7 @@ let regexp_of_pattern env =
         char_pair_op Sedlex.intersection "Intersect" p arg
     | Ppat_construct ({txt = Lident "Chars"}, arg) ->
         begin match arg with
-        | Some {ppat_desc=Ppat_constant (Const_string (s, _))} ->
+        | Some {ppat_desc=Ppat_constant (Pconst_string (s, _))} ->
             let c = ref Cset.empty in
             for i = 0 to String.length s - 1 do
               c := Cset.union !c (Cset.singleton (Char.code s.[i]))
@@ -314,14 +314,14 @@ let regexp_of_pattern env =
             Sedlex.chars !c
         | _ -> err p.ppat_loc "the Chars operator requires a string argument"
         end
-    | Ppat_interval (Const_char c1, Const_char c2) ->
+    | Ppat_interval (Pconst_char c1, Pconst_char c2) ->
         Sedlex.chars (Cset.interval (Char.code c1) (Char.code c2))
-    | Ppat_interval (Const_int i1, Const_int i2) ->
-        Sedlex.chars (Cset.interval (codepoint i1) (codepoint i2))
+    | Ppat_interval (Pconst_integer(i1,_), Pconst_integer(i2,_)) ->
+        Sedlex.chars (Cset.interval (codepoint (int_of_string i1)) (codepoint (int_of_string i2)))
 
-    | Ppat_constant (Const_string (s, _)) -> regexp_for_string s
-    | Ppat_constant (Const_char c) -> regexp_for_char c
-    | Ppat_constant (Const_int c) -> Sedlex.chars (Cset.singleton (codepoint c))
+    | Ppat_constant (Pconst_string (s, _)) -> regexp_for_string s
+    | Ppat_constant (Pconst_char c) -> regexp_for_char c
+    | Ppat_constant (Pconst_integer(c,_)) -> Sedlex.chars (Cset.singleton (codepoint (int_of_string c)))
     | Ppat_var {txt=x} ->
         begin try StringMap.find x env
         with Not_found ->

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -76,7 +76,7 @@ let decision_table p =
 
 
 let appfun s l = app (evar s) l
-let pint i = Pat.constant (Pconst_integer(string_of_int i, None))
+(* let pint i = Pat.constant (Const_int i) *)
 let glb_value name def = Str.value Nonrecursive [Vb.mk (pvar name) def]
 
 (* Named regexps *)
@@ -305,8 +305,12 @@ let regexp_of_pattern env =
     | Ppat_construct ({ txt = Lident "Intersect" }, arg) ->
         char_pair_op Sedlex.intersection "Intersect" p arg
     | Ppat_construct ({txt = Lident "Chars"}, arg) ->
-        begin match arg with
-        | Some {ppat_desc=Ppat_constant (Pconst_string (s, _))} ->
+        let const = (function 
+          | Some {ppat_desc=Ppat_constant (const)} -> Some (constant_type const)
+          | _ -> None) arg 
+        in 
+        begin match const with
+        | Some (Const_string(s,_))->
             let c = ref Cset.empty in
             for i = 0 to String.length s - 1 do
               c := Cset.union !c (Cset.singleton (Char.code s.[i]))
@@ -314,14 +318,19 @@ let regexp_of_pattern env =
             Sedlex.chars !c
         | _ -> err p.ppat_loc "the Chars operator requires a string argument"
         end
-    | Ppat_interval (Pconst_char c1, Pconst_char c2) ->
-        Sedlex.chars (Cset.interval (Char.code c1) (Char.code c2))
-    | Ppat_interval (Pconst_integer(i1,_), Pconst_integer(i2,_)) ->
-        Sedlex.chars (Cset.interval (codepoint (int_of_string i1)) (codepoint (int_of_string i2)))
-
-    | Ppat_constant (Pconst_string (s, _)) -> regexp_for_string s
-    | Ppat_constant (Pconst_char c) -> regexp_for_char c
-    | Ppat_constant (Pconst_integer(c,_)) -> Sedlex.chars (Cset.singleton (codepoint (int_of_string c)))
+    | Ppat_interval (interval1, interval2) -> 
+        begin match constant_type interval1, constant_type interval2 with
+          | Const_char c1, Const_char c2 -> Sedlex.chars (Cset.interval (Char.code c1) (Char.code c2))
+          | Const_int i1, Const_int i2 -> Sedlex.chars (Cset.interval (codepoint i1) (codepoint i2))
+          | _ -> err p.ppat_loc "this pattern is not a valid interval regexp"
+        end 
+    | Ppat_constant (const) -> 
+        begin match constant_type const with 
+          | Const_string (s, _) -> regexp_for_string s
+          | Const_char c -> regexp_for_char c
+          | Const_int c -> Sedlex.chars (Cset.singleton (codepoint c))
+          | _ -> err p.ppat_loc "this pattern is not a valid regexp"
+        end 
     | Ppat_var {txt=x} ->
         begin try StringMap.find x env
         with Not_found ->


### PR DESCRIPTION
This pull request fixes the issue of `sedlex` not building on `ocaml 4.03+beta2`. In addition, current sedlex version in opam is also failing due to the same issue 

A sample error we get is as follows,
```
File "ppx_sedlex.ml", line 79, characters 27-36:
Error: This variant expression is expected to have type Parsetree.constant
       The constructor Const_int does not belong to type Parsetree.constant
```
We get a few other errors all related to the `Parsetree.constant` variant being changed in `4.03`. 

`Parsetree.constant` variant has changed in `4.03`. See [Parsetree.constant 4.03](https://github.com/ocaml/ocaml/blob/trunk/parsing/parsetree.mli#L20)
