### PR TITLE
add support for pattern r{n}/r{n, m}

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,0 +1,5 @@
+PKG compiler-libs ppx_tools ppx_tools.metaquot
+
+SRC src/**
+
+B src/**

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Regular expressions are syntactically OCaml patterns:
 - `Star R` : Kleene star (0 or more repetition)
 - `Plus R` : equivalent to `R, R*`
 - `Opt R` : equivalent to `("" | R)`
+- `Rep (R, n)` : equivalent to `R{n}`
+- `Rep (R, n .. m)` : equivalent to `R{n, m}`
 - `Chars "..."` : recognize any character in the string
 - `Compl R` : assume that R is a single-character length regexp (see below)
   and recognize the complement set

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -5,10 +5,11 @@
 include $(shell ocamlc -where)/Makefile.config
 
 .PHONY: test
-test: tokenizer$(EXE) complement$(EXE) subtraction$(EXE)
+test: tokenizer$(EXE) complement$(EXE) subtraction$(EXE) repeat$(EXE)
 	./tokenizer$(EXE)
 	./complement$(EXE)
 	./subtraction$(EXE)
+	./repeat$(EXE)
 
 tokenizer$(EXE): tokenizer.ml
 	ocamlfind ocamlc -package gen -ppx "../src/syntax/ppx_sedlex$(EXE)" -I ../src/lib -o tokenizer$(EXE) -linkpkg sedlexing.cma tokenizer.ml
@@ -18,6 +19,9 @@ complement$(EXE): complement.ml
 
 subtraction$(EXE): subtraction.ml
 	ocamlfind ocamlc -package gen -ppx "../src/syntax/ppx_sedlex$(EXE)" -I ../src/lib -o subtraction$(EXE) -linkpkg sedlexing.cma subtraction.ml
+
+repeat$(EXE): repeat.ml
+	ocamlfind ocamlc -package gen -ppx "../src/syntax/ppx_sedlex$(EXE)" -I ../src/lib -o repeat$(EXE) -linkpkg sedlexing.cma repeat.ml
 
 .PHONY: with_driver
 with_driver: tokenizer.ml
@@ -29,4 +33,4 @@ with_findlib: tokenizer.ml
 	ocamlfind ocamlc -o tokenizer$(EXE) -linkpkg -package sedlex -package gen tokenizer.cmo
 
 clean:
-	rm -f *~ *.cm* *.a *.lib *.o *.obj tokenizer$(EXE) complement$(EXE) subtraction$(EXE)
+	rm -f *~ *.cm* *.a *.lib *.o *.obj tokenizer$(EXE) complement$(EXE) subtraction$(EXE) repeat$(EXE)

--- a/examples/repeat.ml
+++ b/examples/repeat.ml
@@ -1,0 +1,15 @@
+let rec token buf =
+  match%sedlex buf with
+    | white_space -> print_endline "\tWhitespace"; token buf
+    | 'a', Rep(white_space, 1) -> print_endline "a\n\tWhitespace"; token buf
+    | Rep("bc", 2) -> print_endline "bcbc"; token buf
+    | Rep("d", 1 .. 1) -> print_endline "d"; token buf
+    | Rep("ef", 1 .. 3) -> Printf.printf "%s\n" (Sedlexing.Utf8.lexeme buf); token buf 
+    | eof -> print_endline "\tEnd"
+    | any -> print_endline "Other"; token buf
+    | _ -> failwith "Internal failure: Reached impossible place"
+
+
+let () =
+  let lexbuf = Sedlexing.Utf8.from_string "a bcbc d ef efef efefef" in
+  token lexbuf

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -291,13 +291,18 @@ let regexp_of_pattern env =
           if n == 0 then init else rep1 ~init:(p::init) p (n-1)
         in
         let rep2 p (n, m) =
-          let rec aux p n =
+          let rec aux a n =
             if n == 0 then
-              {p with ppat_desc = Ppat_construct ({lidt with txt = Lident "Opt"}, Some p)}
+              a
             else
-              {p with ppat_desc = Ppat_construct ({lidt with txt = Lident "Opt"}, Some {p with ppat_desc = Ppat_tuple (p :: aux p (n-1) :: [])})}
+              aux {p with ppat_desc = Ppat_construct ({lidt with txt = Lident "Opt"}, Some {p with ppat_desc = Ppat_tuple (p :: a :: [])})} (n-1)
           in
-          if n == m then rep1 p n else rep1 ~init:(aux p (m-n-1)::[]) p n
+          if n = m then
+            rep1 p n
+          else
+            rep1 
+            ~init:(aux {p with ppat_desc = Ppat_construct ({lidt with txt = Lident "Opt"}, Some p)} (m-n-1)::[])
+            p n
         in
         begin match arg with
         | Some {ppat_desc=Ppat_tuple (p0 :: p1 :: []); ppat_loc} ->

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -286,6 +286,42 @@ let regexp_of_pattern env =
         Sedlex.rep (aux p)
     | Ppat_construct ({txt = Lident "Plus"}, Some p) ->
         Sedlex.plus (aux p)
+    | Ppat_construct ({txt = Lident "Rep"} as lidt, arg) ->
+        let rec rep1 ?(init=[]) p n =
+          if n == 0 then init else rep1 ~init:(p::init) p (n-1)
+        in
+        let rep2 p (n, m) =
+          let rec aux p n =
+            if n == 0 then
+              {p with ppat_desc = Ppat_construct ({lidt with txt = Lident "Opt"}, Some p)}
+            else
+              {p with ppat_desc = Ppat_construct ({lidt with txt = Lident "Opt"}, Some {p with ppat_desc = Ppat_tuple (p :: aux p (n-1) :: [])})}
+          in
+          if n == m then rep1 p n else rep1 ~init:(aux p (m-n-1)::[]) p n
+        in
+        begin match arg with
+        | Some {ppat_desc=Ppat_tuple (p0 :: p1 :: []); ppat_loc} ->
+            begin match p1 with
+            | {ppat_desc=Ppat_constant const} as p ->
+                begin match Constant.of_constant const with
+                | Pconst_integer(i1,_) -> aux {p0 with ppat_desc = Ppat_tuple (rep1 p0 (int_of_string i1))}
+                | _ -> err p.ppat_loc "invalid regexp : must be integer constant"
+                end
+            | {ppat_desc=Ppat_interval (i_start, i_end)} as p ->
+                begin match Constant.of_constant i_start, Constant.of_constant i_end with
+                | Pconst_integer(i1,_), Pconst_integer(i2,_) ->
+                    let n1 = int_of_string i1 in
+                    let n2 = int_of_string i2 in
+                    if n1 > n2 then
+                      err p.ppat_loc "invalid range"
+                    else
+                      aux {p0 with ppat_desc = Ppat_tuple (rep2 p0 (n1, n2))}
+                | _ -> err p.ppat_loc "invalid regexp : must be integer interval"
+                end
+            | _ -> err ppat_loc "the Rep operator 2nd argument mus be integer constant/interval"
+            end
+        | _ -> err p.ppat_loc "the Rep operator takes 2 arguments"
+        end
     | Ppat_construct ({txt = Lident "Opt"}, Some p) ->
         Sedlex.alt Sedlex.eps (aux p)
     | Ppat_construct ({txt = Lident "Compl"}, arg) ->

--- a/src/syntax/ppx_sedlex.ml
+++ b/src/syntax/ppx_sedlex.ml
@@ -317,7 +317,7 @@ let regexp_of_pattern env =
                 | Pconst_integer(i1,_), Pconst_integer(i2,_) ->
                     let n1 = int_of_string i1 in
                     let n2 = int_of_string i2 in
-                    if n1 > n2 then
+                    if n1 > n2 || n2 = 0 then
                       err p.ppat_loc "invalid range"
                     else
                       aux {p0 with ppat_desc = Ppat_tuple (rep2 p0 (n1, n2))}


### PR DESCRIPTION
implements #18 via `Rep (r, n)` for repeat n and `Rep (r, n .. m)` for repeat in range n to m.