### PR TITLE
Port to ocaml-migrate-parsetree

### DIFF
--- a/META
+++ b/META
@@ -3,12 +3,12 @@ description = "Runtime support for sedlex"
 archive(byte) = "sedlexing.cma"
 archive(native) = "sedlexing.cmxa"
 requires = "gen"
-ppx = "./ppx_sedlex"
+ppx = "./ppx_sedlex --as-ppx"
 
 package "ppx" (
   version = "1.99.3"
   description = "ppx implementation of sedlex"
-  requires = "ppx_tools gen"
+  requires = "ocaml-migrate-parsetree ppx_tools_versioned gen"
   archive(byte) = "sedlex.cma"
   archive(native) = "sedlex.cmxa"
 )

--- a/opam
+++ b/opam
@@ -8,7 +8,8 @@ build: [ [make "all"]  [make "opt"] ]
 install: [make "install"]
 remove: [["ocamlfind" "remove" "sedlex"]]
 depends: ["ocamlfind" {build}
-          "ppx_tools" {>= "5.0"}
+          "ppx_tools_versioned"
+          "ocaml-migrate-parsetree"
           "gen"
          ]
 available: [ ocaml-version >= "4.02.0" ]

--- a/src/syntax/Makefile
+++ b/src/syntax/Makefile
@@ -5,26 +5,50 @@
 include $(shell ocamlc -where)/Makefile.config
 
 SRCS=sedlex_cset.mli sedlex_cset.ml unicode63.mli unicode63.ml sedlex.mli sedlex.ml ppx_sedlex.ml
-OCAMLC=ocamlfind ocamlc -package ppx_tools.metaquot -w +A-4-9 -annot
-OCAMLOPT=ocamlfind ocamlopt -package ppx_tools.metaquot -w +A-4-9 -annot
+
+OCAMLC=ocamlfind ocamlc
+OCAMLOPT=ocamlfind ocamlopt
+PACKAGES=-package ppx_tools_versioned.metaquot_405 -package ocaml-migrate-parsetree
+OCAMLFLAGS=$(PACKAGES) -linkall -w +A-4-9-42 -annot
 
 all: ppx_sedlex$(EXE) sedlex.cma
 opt: ppx_sedlex.opt$(EXE) sedlex.cmxa sedlex.cmxs
 
 sedlex.cma: $(SRCS)
-	$(OCAMLC) -a -o sedlex.cma $(SRCS)
+	$(OCAMLC) $(OCAMLFLAGS) -a -o sedlex.cma $(SRCS)
 
 sedlex.cmxa: $(SRCS)
-	$(OCAMLOPT) -a -o sedlex.cmxa $(SRCS)
+	$(OCAMLOPT) $(OCAMLFLAGS) -a -o sedlex.cmxa $(SRCS)
 
 sedlex.cmxs: $(SRCS)
-	$(OCAMLOPT) -shared -o sedlex.cmxs $(SRCS)
+	$(OCAMLOPT) $(OCAMLFLAGS) -shared -o sedlex.cmxs $(SRCS)
+
+# We need the ocaml-migrate-parsetree.driver-main.cm{,x}a library to come last
+# on the command-line when linking, since its initialization code must run
+# *after* the one of sedlex.cm{,x}a. To ensure that this is the case, we
+# manually pass its file to ocaml{c,opt}, as normally ocamlfind links in all the
+# -package libraries *before* user code.
+
+MIGRATE_PARSETREE_MAIN_BYTE= \
+  $(shell ocamlfind query -predicates byte -a-format ocaml-migrate-parsetree.driver-main)
+MIGRATE_PARSETREE_MAIN_NATIVE= \
+  $(shell ocamlfind query -predicates native -a-format ocaml-migrate-parsetree.driver-main)
 
 ppx_sedlex$(EXE): sedlex.cma
-	$(OCAMLC) -o $@ -linkpkg -linkall sedlex.cma
+	$(OCAMLC) \
+		-predicates ppx_driver \
+		-o $@ -linkpkg -linkall \
+		-package ppx_tools_versioned \
+		$< \
+		$(MIGRATE_PARSETREE_MAIN_BYTE)
 
 ppx_sedlex.opt$(EXE): sedlex.cmxa
-	$(OCAMLOPT) -o $@ -linkpkg -linkall sedlex.cmxa
+	$(OCAMLOPT) \
+		-predicates ppx_driver \
+		-o $@ -linkpkg -linkall \
+		-package ppx_tools_versioned \
+		$< \
+		$(MIGRATE_PARSETREE_MAIN_NATIVE)
 
 clean:
 	rm -f *~ *.cm* *.a *.lib *.o *.obj *.annot ppx_sedlex$(EXE) ppx_sedlex.opt$(EXE)


### PR DESCRIPTION
This commit ports sedlex to use ocaml-migrate-parsetree, which should ideally
make the project more robust to changes in the OCaml compiler.

We target the latest parsetree (4.05) since ocaml-migrate-parsetree provides
total forward migration functions. As far as I understand, since sedlex does not
generate code relying on features strictly newer than 4.02, this should make it
compatible with all OCaml versions from 4.02 to 4.05 (and later as soon as the
input file does not contain 4.06+-specific features).

Rather than registering an Ast_mapper function, sedlex now uses the driver API
provided by ocaml-migrate-parsetree. This makes it possible to combine several
ppx rewriters into a single one, speeding up compilation time. A practical side
effect is that sedlex is now easy to use with the jbuilder build system, solving #46.